### PR TITLE
godoc + go get documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,15 @@ by the European Community’s Seventh Framework Programme (Capacities)
 Grant Agreement H2020-IA-644925, started in Jan 2015
 
 
+Installation
+------------
+
+Installing `fedid` is done via `go get`:
+
+```sh
+$ go get github.com/lodygens/fedid
+```
+
 [Documentation](doc/fedid.md)
 =============
 

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,7 @@
+// fedid provides an identity federator service enabling user connection thru
+// different identity providers.
+//
+// For more informations, see:
+//   https://github.com/lodygens/fedid/blob/master/doc/fedid.md
+//
+package main

--- a/doc/fedid.md
+++ b/doc/fedid.md
@@ -29,6 +29,12 @@ One can easily installs them :
 $> go get github.com/apexskier/httpauth github.com/gorilla/mux golang.org/x/oauth2 
 ```
 
+But all dependencies of `fedid` should have been automatically installed with:
+
+```sh
+$ go get github.com/lodygens/fedid
+```
+
 
 ## Configuration
 


### PR DESCRIPTION
- mention `go get` for easy installation
- add godoc documentation (linking back to github)
